### PR TITLE
修复IOThreadManager的mCurrentThreadMode线程同步问题

### DIFF
--- a/socket-client/src/main/java/com/xuhao/didi/socket/client/impl/client/iothreads/IOThreadManager.java
+++ b/socket-client/src/main/java/com/xuhao/didi/socket/client/impl/client/iothreads/IOThreadManager.java
@@ -63,7 +63,7 @@ public class IOThreadManager implements IIOManager<OkSocketOptions> {
     }
 
     @Override
-    public void startEngine() {
+    public synchronized void startEngine() {
         mCurrentThreadMode = mOkOptions.getIOThreadMode();
         //初始化读写工具类
         mReader.setOption(mOkOptions);
@@ -112,7 +112,7 @@ public class IOThreadManager implements IIOManager<OkSocketOptions> {
     }
 
     @Override
-    public void setOkOptions(OkSocketOptions options) {
+    public synchronized void setOkOptions(OkSocketOptions options) {
         mOkOptions = options;
         if (mCurrentThreadMode == null) {
             mCurrentThreadMode = mOkOptions.getIOThreadMode();
@@ -135,7 +135,7 @@ public class IOThreadManager implements IIOManager<OkSocketOptions> {
     }
 
     @Override
-    public void close(Exception e) {
+    public synchronized void close(Exception e) {
         shutdownAllThread(e);
         mCurrentThreadMode = null;
     }


### PR DESCRIPTION
复现步骤
为了扩大问题，首先修改IOThreadManager的setOkOptions方法中，在mCurrentThreadMode赋值后sleep了三秒。
1 打开长链， 关闭长链（为了复用ConnectionManagerImpl中的mManager）。
2 开启一个子线程调用延迟500ms调用Manager.disconnect，开启线程的同时调用
 OkSocket.open(mInfo).option(mOkOptions).connect()即可复现